### PR TITLE
Fixing usage of a deprecated method in pandas

### DIFF
--- a/cmctoolkit.py
+++ b/cmctoolkit.py
@@ -1097,6 +1097,7 @@ class Snapshot:
                                      })
 
             self.filtertable = pd.concat([self.filtertable, pd.DataFrame(filterrow)],ignore_index=True)
+          
     def make_2d_projection(self, seed=0):
         """
         Appends to a snapshot table a column projecting stellar positions onto the

--- a/cmctoolkit.py
+++ b/cmctoolkit.py
@@ -1096,8 +1096,7 @@ class Snapshot:
            'zp_spectralflux[ERG/S/CM2/ANGSTROM]': [filttable.loc[ii,'zp_spectralflux[ERG/S/CM2/ANGSTROM]']],
                                      })
 
-            self.filtertable = self.filtertable.append(filterrow, ignore_index=True)
-
+            self.filtertable = pd.concat([self.filtertable, pd.DataFrame(filterrow)],ignore_index=True)
     def make_2d_projection(self, seed=0):
         """
         Appends to a snapshot table a column projecting stellar positions onto the


### PR DESCRIPTION
Starting from pandas 2.x.x, the `.append` method has been removed due to deprecation, legacy versions of `pandas` (1.x.x) are no longer supported by the latest version of python (3.12), this can be fixed by replacing `.append` with` .concat`.

Thanks!